### PR TITLE
Trying to get this java 8 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
-sudo: false
+sudo: required
+dist: trusty
 
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-sudo: required
-dist: trusty
+sudo: false
 
 jdk:
   - oraclejdk7

--- a/hystrix-core/src/main/java/com/netflix/hystrix/Commands.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/Commands.java
@@ -1,0 +1,24 @@
+package com.netflix.hystrix;
+
+/**
+ * Utility class to create HystrixCommand in a shorthen way
+ */
+public final class Commands {
+  
+  private Commands() {
+    super();
+  }
+
+  public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command) {
+    return execute(group, command, (LambdaCommandFallback<E>) null);
+  }
+  
+  public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command, E fallbackValue) {
+    return execute(group, command, new ConstFallback<E>(fallbackValue));
+  }
+
+  public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command, LambdaCommandFallback<E> fallback) {
+    return new HystrixLambdaCommand<E>(group, command, fallback).execute();
+  }
+
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/ConstFallback.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/ConstFallback.java
@@ -1,0 +1,17 @@
+package com.netflix.hystrix;
+
+public class ConstFallback<E> implements LambdaCommandFallback<E> {
+
+  private final E value;
+
+  public ConstFallback(E value) {
+    super();
+    this.value = value;
+  }
+
+  @Override
+  public E fallback() {
+    return value;
+  }
+
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
@@ -205,4 +205,14 @@ public class Hystrix {
             }
         }
     }
+
+
+    public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command) {
+      return execute(group, command, null);
+    }
+
+    public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command, LambdaCommandFallback<E> fallback) {
+      return new HystrixLambdaCommand<E>(group, command, fallback).execute();
+    }
+
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
@@ -206,12 +206,4 @@ public class Hystrix {
         }
     }
 
-    public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command) {
-      return execute(group, command, null);
-    }
-
-    public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command, LambdaCommandFallback<E> fallback) {
-      return new HystrixLambdaCommand<E>(group, command, fallback).execute();
-    }
-
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
@@ -206,7 +206,6 @@ public class Hystrix {
         }
     }
 
-
     public static <E> E execute(HystrixCommandGroupKey group, LambdaCommand<E> command) {
       return execute(group, command, null);
     }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixLambdaCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixLambdaCommand.java
@@ -1,0 +1,31 @@
+package com.netflix.hystrix;
+
+public class HystrixLambdaCommand<E> extends HystrixCommand<E>
+{
+
+  private final LambdaCommand<E> command;
+  private final LambdaCommandFallback<E> fallback;
+
+  public HystrixLambdaCommand(HystrixCommandGroupKey group, LambdaCommand<E> command, LambdaCommandFallback<E> fallback)
+  {
+    super(group);
+    this.command = command;
+    this.fallback = fallback;
+  }
+
+  @Override
+  protected E run() throws Exception
+  {
+    return command.run();
+  }
+
+  @Override
+  protected E getFallback()
+  {
+    if (this.fallback == null)
+      return super.getFallback();
+    else
+      return fallback.fallback();
+  }
+
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/LambdaCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/LambdaCommand.java
@@ -1,0 +1,8 @@
+package com.netflix.hystrix;
+
+public interface LambdaCommand<E>
+{
+
+  E run() throws Exception;
+  
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/LambdaCommandFallback.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/LambdaCommandFallback.java
@@ -1,0 +1,8 @@
+package com.netflix.hystrix;
+
+public interface LambdaCommandFallback<E>
+{
+
+  E fallback();
+
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixRequestContext.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixRequestContext.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.hystrix.strategy.concurrency;
 
+import java.io.Closeable;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.netflix.hystrix.HystrixCollapser;
@@ -60,7 +61,7 @@ import com.netflix.hystrix.HystrixRequestLog;
  * <p>
  * <b>NOTE:</b> If <code>initializeContext()</code> is called then <code>shutdown()</code> must also be called or a memory leak will occur.
  */
-public class HystrixRequestContext {
+public class HystrixRequestContext implements Closeable {
 
     /*
      * ThreadLocal on each thread will hold the HystrixRequestVariableState.
@@ -142,4 +143,16 @@ public class HystrixRequestContext {
             state = null;
         }
     }
+
+    /**
+     * Shutdown {@link HystrixRequestVariableDefault} objects in this context.
+     * <p>
+     * <b>NOTE: This must be called if <code>initializeContext()</code> was called or a memory leak will occur.</b>
+     *
+     * This method invokes <code>shutdown()</code>
+     */
+    public void close() {
+      shutdown();
+    }
+
 }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/CommandsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/CommandsTest.java
@@ -1,0 +1,84 @@
+package com.netflix.hystrix;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+
+public class CommandsTest
+{
+  
+  private static final LambdaCommand<Integer> EXCEPTION_COMMAND = new LambdaCommand<Integer>() {
+    @Override
+    public Integer run() throws Exception {
+      throw new RuntimeException();
+    }
+  };
+  
+  private static final HystrixCommandGroupKey GROUP_KEY = HystrixCommandGroupKey.Factory.asKey("unitest");
+  
+  private HystrixRequestContext context;
+
+  @Before
+  public void setup() {
+    context = HystrixRequestContext.initializeContext();
+  }
+  
+  @After
+  public void shutdown() {
+    context.close();
+  }
+
+  @Test
+  public void testExecute()
+  {
+    final int number = 7;
+
+    int result = Commands.execute(GROUP_KEY, new LambdaCommand<Integer>() {
+      @Override
+      public Integer run() throws Exception {
+        return number * 10;
+      }
+    });
+    Assert.assertEquals(70, result);
+  }
+  
+  @Test
+  public void testFallback()
+  {
+    int result = Commands.execute(GROUP_KEY, EXCEPTION_COMMAND, new LambdaCommandFallback<Integer>() {
+      @Override
+      public Integer fallback() {
+        return -1;
+      }
+    });
+    Assert.assertEquals(-1, result);
+  }
+  
+  @Test
+  public void testNoFallback()
+  {
+    try
+    {
+      Commands.execute(GROUP_KEY, EXCEPTION_COMMAND);
+      fail("Command should have thrown an exception");
+    }
+    catch (HystrixRuntimeException e)
+    {
+      Assert.assertTrue(e.getMessage().contains("no fallback available."));
+    }
+  }
+
+  @Test
+  public void testConstFallback()
+  {
+    int result = Commands.execute(GROUP_KEY, EXCEPTION_COMMAND, -7);
+    Assert.assertEquals(-7, result);
+  }
+  
+}


### PR DESCRIPTION
The end game here is to be able to use Hystrix with java 8 lambdas

```
    try (HystrixRequestContext context = HystrixRequestContext.initializeContext();)
    {
      int result = execute(HystrixCommandGroupKey.Factory.asKey("unittest"), () -> number * 10);
      Assert.assertEquals(70, result);
    }

```
